### PR TITLE
check for additional JUnit5 test annotations

### DIFF
--- a/com.wamas.ide.launching.ui/src/com/wamas/ide/launching/ui/contentassist/LcDslProposalProvider.xtend
+++ b/com.wamas.ide.launching.ui/src/com/wamas/ide/launching/ui/contentassist/LcDslProposalProvider.xtend
@@ -12,23 +12,18 @@ import com.wamas.ide.launching.lcDsl.TraceEnablement
 import com.wamas.ide.launching.services.LcDslGrammarAccess
 import com.wamas.ide.launching.validation.LcDslValidator
 import java.util.stream.Stream
-import javax.swing.plaf.synth.Region
 import org.eclipse.core.resources.IContainer
-import org.eclipse.core.resources.IFile
 import org.eclipse.core.resources.IResource
 import org.eclipse.core.resources.ResourcesPlugin
 import org.eclipse.core.runtime.IPath
-import org.eclipse.core.runtime.NullProgressMonitor
 import org.eclipse.core.runtime.Path
 import org.eclipse.emf.ecore.EObject
 import org.eclipse.jdt.core.Flags
-import org.eclipse.jdt.core.ICompilationUnit
 import org.eclipse.jdt.core.IJavaElement
 import org.eclipse.jdt.core.IJavaProject
 import org.eclipse.jdt.core.IMethod
 import org.eclipse.jdt.core.IPackageFragment
 import org.eclipse.jdt.core.IPackageFragmentRoot
-import org.eclipse.jdt.core.IType
 import org.eclipse.jdt.core.JavaCore
 import org.eclipse.jdt.core.search.IJavaSearchConstants
 import org.eclipse.jdt.core.search.IJavaSearchScope
@@ -50,7 +45,6 @@ import org.eclipse.xtext.ui.editor.contentassist.ConfigurableCompletionProposal
 import org.eclipse.xtext.ui.editor.contentassist.ContentAssistContext
 import org.eclipse.xtext.ui.editor.contentassist.ICompletionProposalAcceptor
 import org.eclipse.xtext.ui.editor.contentassist.ICompletionProposalAcceptor.Delegate
-import java.util.stream.Collectors
 
 /**
  * See https://www.eclipse.org/Xtext/documentation/304_ide_concepts.html#content-assist
@@ -380,7 +374,7 @@ class LcDslProposalProvider extends AbstractLcDslProposalProvider {
 		}
 
 		private def boolean isTestMethod(IMethod method) {
-			return Flags.isPublic(method.flags) && method.annotations.stream().anyMatch([a | a.elementName.equals("Test")])
+			return Flags.isPublic(method.flags) && method.annotations.stream().anyMatch([annotation | LcDslValidator.TEST_ANNOTATION_NAMES.contains(annotation.elementName)])
 		}
 
 		override protected getImage(EObject eObject) {

--- a/com.wamas.ide.launching/src/com/wamas/ide/launching/validation/LcDslValidator.xtend
+++ b/com.wamas.ide.launching/src/com/wamas/ide/launching/validation/LcDslValidator.xtend
@@ -366,7 +366,7 @@ class LcDslValidator extends AbstractLcDslValidator {
 		} else if (!Flags.isPublic(type.flags)) {
 			error("Test class " + className + " must be public.", cfg.test, LC.testConfig_Class)
 		} else if (type.methods.stream().filter([method | Flags.isPublic(method.flags)]).flatMap([method | method.annotations.stream]).noneMatch([annotation | TEST_ANNOTATION_NAMES.contains(annotation.elementName)])) {
-			error("Test class " + className + " must at least have one method annotated with @Test.", cfg.test, LC.testConfig_Class)
+			error("Test class " + className + " must at least have one method annotated with one annotation out of " + TEST_ANNOTATION_NAMES, cfg.test, LC.testConfig_Class)
 		}
 	}
 
@@ -422,7 +422,7 @@ class LcDslValidator extends AbstractLcDslValidator {
 			} else if (type.methods.stream().filter([method|method.elementName.equals(methodName)]).noneMatch([method | Flags.isPublic(method.flags)])) {
 				error("Test method " + methodName + "  in class " + className + " must be public", cfg.test, LC.testConfig_Method)
 			} else if (type.methods.stream().filter([method|method.elementName.equals(methodName)]).flatMap([method | method.annotations.stream]).noneMatch([annotation | TEST_ANNOTATION_NAMES.contains(annotation.elementName)])) {
-				error("Test method " + methodName + "  in class " + className + " does not have a @Test annotation", cfg.test, LC.testConfig_Method)
+				error("Test method " + methodName + "  in class " + className + " does not have at least one annotation out of " + TEST_ANNOTATION_NAMES, cfg.test, LC.testConfig_Method)
 			}
 		}
 	}

--- a/com.wamas.ide.launching/src/com/wamas/ide/launching/validation/LcDslValidator.xtend
+++ b/com.wamas.ide.launching/src/com/wamas/ide/launching/validation/LcDslValidator.xtend
@@ -44,6 +44,7 @@ import org.eclipse.pde.internal.core.PDECore
 import org.eclipse.xtext.validation.Check
 
 import static com.wamas.ide.launching.lcDsl.LaunchConfigType.*
+import org.eclipse.jdt.core.IAnnotation
 
 /**
  * This class contains custom validation rules. 
@@ -54,6 +55,8 @@ class LcDslValidator extends AbstractLcDslValidator {
 
 	public static val EXT_APPLICATIONS = "org.eclipse.core.runtime.applications"
 	public static val EXT_PRODUCTS = "org.eclipse.core.runtime.products"
+
+	public static final List<String> TEST_ANNOTATION_NAMES = List.of("Test", "ParameterizedTest", "TestTemplate", "TestFactory")
 
 	LcDslPackage LC = LcDslPackage.eINSTANCE
 
@@ -362,7 +365,7 @@ class LcDslValidator extends AbstractLcDslValidator {
 			error("Test class " + className + " must point to an existing class in project " + javaProject, cfg.test, LC.testConfig_Class)
 		} else if (!Flags.isPublic(type.flags)) {
 			error("Test class " + className + " must be public.", cfg.test, LC.testConfig_Class)
-		} else if (type.methods.stream().filter([method | Flags.isPublic(method.flags)]).flatMap([method | method.annotations.stream]).noneMatch([annotation | annotation.elementName.equals("Test")])) {
+		} else if (type.methods.stream().filter([method | Flags.isPublic(method.flags)]).flatMap([method | method.annotations.stream]).noneMatch([annotation | TEST_ANNOTATION_NAMES.contains(annotation.elementName)])) {
 			error("Test class " + className + " must at least have one method annotated with @Test.", cfg.test, LC.testConfig_Class)
 		}
 	}
@@ -418,7 +421,7 @@ class LcDslValidator extends AbstractLcDslValidator {
 				error("Test method " + methodName + " does not exist in class " + className, cfg.test, LC.testConfig_Method)
 			} else if (type.methods.stream().filter([method|method.elementName.equals(methodName)]).noneMatch([method | Flags.isPublic(method.flags)])) {
 				error("Test method " + methodName + "  in class " + className + " must be public", cfg.test, LC.testConfig_Method)
-			} else if (type.methods.stream().filter([method|method.elementName.equals(methodName)]).flatMap([method | method.annotations.stream]).noneMatch([annotation | annotation.elementName.equals("Test")])) {
+			} else if (type.methods.stream().filter([method|method.elementName.equals(methodName)]).flatMap([method | method.annotations.stream]).noneMatch([annotation | TEST_ANNOTATION_NAMES.contains(annotation.elementName)])) {
 				error("Test method " + methodName + "  in class " + className + " does not have a @Test annotation", cfg.test, LC.testConfig_Method)
 			}
 		}


### PR DESCRIPTION
We have some ParameterizedTest using JUnit5 where validation and content assist did not support it. Best would be to check for @Testable annotation (base for any kind of JUnit5 test) but seems that the JDT class model is capable to get that information.