### PR TITLE
fix NPE for project="self"

### DIFF
--- a/com.wamas.ide.launching/src/com/wamas/ide/launching/generator/RecursiveCollectors.xtend
+++ b/com.wamas.ide.launching/src/com/wamas/ide/launching/generator/RecursiveCollectors.xtend
@@ -69,11 +69,15 @@ class RecursiveCollectors {
 	}
 
 	static def collectJavaMainProject(LaunchConfig config) {
+		collectJavaMainProject(config, config.eResource)
+	}
+	
+	static def collectJavaMainProject(LaunchConfig config, org.eclipse.emf.ecore.resource.Resource eResource) {
 		val prjName = collectFlatObject(config, [mainProject?.project?.name])
 		if (prjName === null) {
 			val s = collectFlatBoolean(config, true, [mainProject?.self])
 			if (s) {
-				return ResourcesPlugin.workspace.root.getFile(new Path(config.eResource.URI.toPlatformString(true)))?.
+				return ResourcesPlugin.workspace.root.getFile(new Path(eResource.URI.toPlatformString(true)))?.
 					project?.name
 			}
 		}
@@ -276,8 +280,8 @@ class RecursiveCollectors {
 		collectFlatEnvMap(config)
 	}
 
-	static def collectTestProject(LaunchConfig config) {
-		collectTestContainerResource(config)?.project?.name
+	static def collectTestProject(LaunchConfig config, org.eclipse.emf.ecore.resource.Resource eResource) {
+		collectTestContainerResource(config, eResource)?.project?.name
 	}
 
 	static def collectTestKind(LaunchConfig config) {
@@ -302,12 +306,12 @@ class RecursiveCollectors {
 		collectFlatObject(config, [test?.container])
 	}
 
-	static def collectTestContainer(LaunchConfig config) {
+	static def collectTestContainer(LaunchConfig config, org.eclipse.emf.ecore.resource.Resource eResource) {
 		if (config.collectTestMainType !== null) {
 			return "";
 		}
 
-		val testContainerResource = collectTestContainerResource(config)
+		val testContainerResource = collectTestContainerResource(config, eResource)
 		var javaElement = JavaCore.create(testContainerResource)
 		var testContainer = ""
 
@@ -336,14 +340,18 @@ class RecursiveCollectors {
 		return '.' + javaElement.elementName
 	}
 	
-	static def collectTestResources(LaunchConfig config) {
-		#[collectTestContainerResource(config)]
+	static def collectTestResources(LaunchConfig config, org.eclipse.emf.ecore.resource.Resource eResource) {
+		#[collectTestContainerResource(config, eResource)]
 	}
 
 	static def collectTestContainerResource(LaunchConfig config) {
+		collectTestContainerResource(config, config.eResource)
+	}
+	
+	static def collectTestContainerResource(LaunchConfig config, org.eclipse.emf.ecore.resource.Resource eResource) {
 		val containerPath = collectTestContainerPlain(config)
 		if (containerPath === null) {
-			return ResourcesPlugin.workspace.root.findMember(config.eResource.URI.toPlatformString(true))?.project
+			return ResourcesPlugin.workspace.root.findMember(eResource.URI.toPlatformString(true))?.project
 		}
 
 		return ResourcesPlugin.workspace.root.findMember(containerPath)

--- a/com.wamas.ide.launching/src/com/wamas/ide/launching/generator/StandaloneLaunchConfigGenerator.xtend
+++ b/com.wamas.ide.launching/src/com/wamas/ide/launching/generator/StandaloneLaunchConfigGenerator.xtend
@@ -195,8 +195,12 @@ class StandaloneLaunchConfigGenerator {
 		return model;
 	}
 
+ /**  command line arguments need to be quoted with single or double quote if they contain a space **/
 	def quote(String string) {
-		if(string.contains('"')) {
+		if (!string.contains(' ')) {
+			return string
+		}
+		if (string.contains('"')) {
 			return string; // quoted itself already?
 		}
 		return '"' + string + '"';

--- a/com.wamas.ide.launching/src/com/wamas/ide/launching/generator/StandaloneLaunchConfigGenerator.xtend
+++ b/com.wamas.ide.launching/src/com/wamas/ide/launching/generator/StandaloneLaunchConfigGenerator.xtend
@@ -160,7 +160,7 @@ class StandaloneLaunchConfigGenerator {
 
 		switch (config.type) {
 			case LaunchConfigType.JAVA:
-				generateJava(config, copy)
+				generateJava(c.eResource, config, copy)
 			case ECLIPSE:
 				generateEclipse(config, copy)
 			case GROUP:
@@ -168,9 +168,9 @@ class StandaloneLaunchConfigGenerator {
 			case RAP:
 				generateRAP(config, copy)
 			case SWTBOT:
-				generateSWTBotJUnitPlugin(config, copy)
+				generateSWTBotJUnitPlugin(c.eResource, config, copy)
 			case JUNIT_PLUGIN:
-				generatJUnitPlugin(config, copy)
+				generatJUnitPlugin(c.eResource, config, copy)
 		}
 
 		copy.doSave
@@ -245,9 +245,9 @@ class StandaloneLaunchConfigGenerator {
 		return type.newInstance(null, config.fullName)
 	}
 
-	def generateJava(LaunchConfig config, ILaunchConfigurationWorkingCopy copy) {
+	def generateJava(org.eclipse.emf.ecore.resource.Resource eResource, LaunchConfig config, ILaunchConfigurationWorkingCopy copy) {
 		copy.setIfAvailable(IJavaLaunchConfigurationConstants.ATTR_MAIN_TYPE_NAME, config.collectJavaMainType)
-		copy.setIfAvailable(IJavaLaunchConfigurationConstants.ATTR_PROJECT_NAME, config.collectJavaMainProject)
+		copy.setIfAvailable(IJavaLaunchConfigurationConstants.ATTR_PROJECT_NAME, config.collectJavaMainProject(eResource))
 		copy.setAttribute(IJavaLaunchConfigurationConstants.ATTR_STOP_IN_MAIN, config.collectJavaStopInMain)
 
 		copy.setAttribute("org.eclipse.jdt.debug.ui.CONSIDER_INHERITED_MAIN", config.collectJavaMainSearchInherited)
@@ -442,21 +442,21 @@ class StandaloneLaunchConfigGenerator {
 		}
 	}
 
-	def generatJUnitPlugin(LaunchConfig config, ILaunchConfigurationWorkingCopy copy) {
-		generateSWTBotJUnitPlugin(config, copy)
+	def generatJUnitPlugin(org.eclipse.emf.ecore.resource.Resource eResource, LaunchConfig config, ILaunchConfigurationWorkingCopy copy) {
+		generateSWTBotJUnitPlugin(eResource, config, copy)
 
 		copy.setAttribute(IPDELauncherConstants.RUN_IN_UI_THREAD, config.collectTestRunUiThread)
 	}
 
-	def generateSWTBotJUnitPlugin(LaunchConfig config, ILaunchConfigurationWorkingCopy copy) {
+	def generateSWTBotJUnitPlugin(org.eclipse.emf.ecore.resource.Resource eResource, LaunchConfig config, ILaunchConfigurationWorkingCopy copy) {
 		generateEclipse(config, copy)
 
-		copy.mappedResources = config.collectTestResources
+		copy.mappedResources = config.collectTestResources(eResource)
 
-		copy.setAttribute(IJavaLaunchConfigurationConstants.ATTR_PROJECT_NAME, config.collectTestProject)
+		copy.setAttribute(IJavaLaunchConfigurationConstants.ATTR_PROJECT_NAME, config.collectTestProject(eResource))
 		copy.setAttribute(JUnitLaunchConfigurationConstants.ATTR_TEST_RUNNER_KIND, config.collectTestKind)
 		copy.setAttribute(JUnitLaunchConfigurationConstants.ATTR_KEEPRUNNING, config.collectTestKeepRunning)
-		copy.setAttribute(JUnitLaunchConfigurationConstants.ATTR_TEST_CONTAINER, config.collectTestContainer)
+		copy.setAttribute(JUnitLaunchConfigurationConstants.ATTR_TEST_CONTAINER, config.collectTestContainer(eResource))
 		copy.setAttribute(IJavaLaunchConfigurationConstants.ATTR_MAIN_TYPE_NAME, config.collectTestMainType)
 		copy.setAttribute(JUnitLaunchConfigurationConstants.ATTR_TEST_NAME, config.collectTestName)
 


### PR DESCRIPTION
example:

java configuration Launch{
	project self; 
	main-class my.Main;
}

config.eResource is null after taking a copy

java.lang.NullPointerException
	at com.wamas.ide.launching.generator.RecursiveCollectors.collectJavaMainProject(RecursiveCollectors.java:228)
	at com.wamas.ide.launching.generator.StandaloneLaunchConfigGenerator.generateJava(StandaloneLaunchConfigGenerator.java:324)
	at com.wamas.ide.launching.generator.StandaloneLaunchConfigGenerator.generate(StandaloneLaunchConfigGenerator.java:207)
	at com.wamas.ide.launching.generator.LcDslGenerator.doGenerate(LcDslGenerator.java:44)
	at org.eclipse.xtext.generator.GeneratorDelegate.doGenerate(GeneratorDelegate.java:44)
	at org.eclipse.xtext.generator.GeneratorDelegate.generate(GeneratorDelegate.java:35)
	at org.eclipse.xtext.builder.BuilderParticipant.handleChangedContents(BuilderParticipant.java:597)
	at org.eclipse.xtext.builder.BuilderParticipant.handleChangedContents(BuilderParticipant.java:578)
	at org.eclipse.xtext.builder.BuilderParticipant.doGenerate(BuilderParticipant.java:563)
	at org.eclipse.xtext.builder.BuilderParticipant.doBuild(BuilderParticipant.java:303)
	at org.eclipse.xtext.builder.BuilderParticipant.build(BuilderParticipant.java:265)
	at org.eclipse.xtext.builder.impl.RegistryBuilderParticipant$DeferredBuilderParticipant.build(RegistryBuilderParticipant.java:164)
	at org.eclipse.xtext.builder.impl.RegistryBuilderParticipant.build(RegistryBuilderParticipant.java:70)
	at org.eclipse.xtext.builder.impl.XtextBuilder.doBuild(XtextBuilder.java:392)
	at org.eclipse.xtext.builder.impl.XtextBuilder.addInfosFromTaskAndBuild(XtextBuilder.java:322)
	at org.eclipse.xtext.builder.impl.XtextBuilder.incrementalBuild(XtextBuilder.java:303)
	at org.eclipse.xtext.builder.impl.XtextBuilder.build(XtextBuilder.java:208)
	at org.eclipse.core.internal.events.BuildManager$2.run(BuildManager.java:855)
	at org.eclipse.core.runtime.SafeRunner.run(SafeRunner.java:45)
	at org.eclipse.core.internal.events.BuildManager.basicBuild(BuildManager.java:233)
	at org.eclipse.core.internal.events.BuildManager.basicBuild(BuildManager.java:283)
	at org.eclipse.core.internal.events.BuildManager$1.run(BuildManager.java:336)
	at org.eclipse.core.runtime.SafeRunner.run(SafeRunner.java:45)
	at org.eclipse.core.internal.events.BuildManager.basicBuild(BuildManager.java:339)
	at org.eclipse.core.internal.events.BuildManager.basicBuildLoop(BuildManager.java:391)
	at org.eclipse.core.internal.events.BuildManager.build(BuildManager.java:412)
	at org.eclipse.core.internal.events.AutoBuildJob.doBuild(AutoBuildJob.java:160)
	at org.eclipse.core.internal.events.AutoBuildJob.run(AutoBuildJob.java:251)
	at org.eclipse.core.internal.jobs.Worker.run(Worker.java:63)

WPL-314
