### PR TITLE
fix silent NPE during Validation

### DIFF
--- a/com.wamas.ide.launching/src/com/wamas/ide/launching/validation/LcDslValidator.xtend
+++ b/com.wamas.ide.launching/src/com/wamas/ide/launching/validation/LcDslValidator.xtend
@@ -535,7 +535,7 @@ class LcDslValidator extends AbstractLcDslValidator {
 			point.equals(ext)
 		].map[
 			// if the id contains a '.' the bundle name should not be prepended
-			if(id.contains('.')) { id } else { pluginModel.bundleDescription.symbolicName + "." + id }
+			if(id === null || id.contains('.') || pluginModel.bundleDescription===null) { id } else { pluginModel.bundleDescription.symbolicName + "." + id }
 		]
 	}
 	


### PR DESCRIPTION
when referencing a product which is not part of workspace.

Caused by: java.lang.NullPointerException
	at com.wamas.ide.launching.validation.LcDslValidator.lambda$12(LcDslValidator.java:731)
	at org.eclipse.xtext.xbase.lib.internal.FunctionDelegate.apply(FunctionDelegate.java:43)
	at com.google.common.collect.Iterators$6.transform(Iterators.java:783)
	at com.google.common.collect.TransformedIterator.next(TransformedIterator.java:47)
	at com.google.common.collect.Iterators.addAll(Iterators.java:356)
	at com.google.common.collect.Iterables.addAll(Iterables.java:320)
	at com.google.common.collect.Sets.newLinkedHashSet(Sets.java:329)
	at org.eclipse.xtext.xbase.lib.IterableExtensions.toSet(IterableExtensions.java:640)
	at com.wamas.ide.launching.validation.LcDslValidator.checkProduct(LcDslValidator.java:647)