### PR TITLE
fix org.eclipse.core.runtime startlevel to default.

### DIFF
--- a/com.wamas.ide.launching/src/com/wamas/ide/launching/generator/StandaloneLaunchConfigGenerator.xtend
+++ b/com.wamas.ide.launching/src/com/wamas/ide/launching/generator/StandaloneLaunchConfigGenerator.xtend
@@ -52,7 +52,7 @@ class StandaloneLaunchConfigGenerator {
 	val knownStartLevels = newHashMap(
 		"org.eclipse.osgi" -> "@-1:true",
 		"org.apache.felix.scr" -> "@2:true",
-		"org.eclipse.core.runtime" -> "@0:true",
+		"org.eclipse.core.runtime" -> "@default:true",
 		"org.eclipse.equinox.common" -> "@2:true",
 		"org.eclipse.equinox.event" -> "@2:true",
 		"org.eclipse.equinox.simpleconfigurator" -> "@1:true"


### PR DESCRIPTION
see PluginConfigurationSection.getBundlesWithStartLevels()

With level 0 an error can occur at startup:
java.lang.IllegalArgumentException: Cannot set the start level to less
than 1: 0
	at org.eclipse.osgi.container.ModuleContainer$ContainerStartLevel.setStartLevel(ModuleContainer.java:1596)
	at org.eclipse.osgi.container.ModuleContainer.setStartLevel(ModuleContainer.java:1182)
	at org.eclipse.osgi.container.Module.setStartLevel(Module.java:259)
	at org.eclipse.core.runtime.adaptor.EclipseStarter.installBundles(EclipseStarter.java:1000)
	at org.eclipse.core.runtime.adaptor.EclipseStarter.loadBasicBundles(EclipseStarter.java:596)
	at org.eclipse.core.runtime.adaptor.EclipseStarter.startup(EclipseStarter.java:331)
	at org.eclipse.core.runtime.adaptor.EclipseStarter.run(EclipseStarter.java:251)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native
Method)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.base/java.lang.reflect.Method.invoke(Method.java:566)
	at org.eclipse.equinox.launcher.Main.invokeFramework(Main.java:659)
	at org.eclipse.equinox.launcher.Main.basicRun(Main.java:596)
	at org.eclipse.equinox.launcher.Main.run(Main.java:1467)
	at org.eclipse.equinox.launcher.Main.main(Main.java:1440)