### PR TITLE
just prerequisites are "interesting projects" for a builder

### DIFF
--- a/com.wamas.ide.launching.ui/src/com/wamas/ide/launching/ui/build/LcDslTargetPlatformSupport.java
+++ b/com.wamas.ide.launching.ui/src/com/wamas/ide/launching/ui/build/LcDslTargetPlatformSupport.java
@@ -404,16 +404,6 @@ public class LcDslTargetPlatformSupport implements IStorage2UriMapperContributio
 	}
 
 	@Override
-	public void addInterestingProjects(IProject thisProject, Set<IProject> result) {
-		IWorkspaceRoot root = ResourcesPlugin.getWorkspace().getRoot();
-		for (IProject project : root.getProjects()) {
-			if (!project.equals(thisProject) && XtextProjectHelper.hasBuilder(project)) {
-				result.add(project);
-			}
-		}
-	}
-
-	@Override
 	public void stateResolved(StateDelta delta) {
 		// nothing to do
 	}


### PR DESCRIPTION
Only the particular project's prerequisites are "interesting projects"
for this project's Xtext builder. Otherwise, we would end with
dependency circles causing needless auto build runs.
As the ToBeBuiltComputer already does add the "referenced projects",
there is nothing left to do for addInterestingProjects().