### PR TITLE
Fix most warnings

### DIFF
--- a/com.wamas.ide.launching.ide/.settings/org.eclipse.xtend.core.Xtend.prefs
+++ b/com.wamas.ide.launching.ide/.settings/org.eclipse.xtend.core.Xtend.prefs
@@ -1,0 +1,3 @@
+ValidatorConfiguration.is_project_specific=true
+eclipse.preferences.version=1
+org.eclipse.xtext.xbase.validation.IssueCodes.null_safe_feature_call_on_primitive_valued_feature=ignore

--- a/com.wamas.ide.launching.ui/.settings/org.eclipse.jdt.core.prefs
+++ b/com.wamas.ide.launching.ui/.settings/org.eclipse.jdt.core.prefs
@@ -3,5 +3,6 @@ org.eclipse.jdt.core.compiler.codegen.inlineJsrBytecode=enabled
 org.eclipse.jdt.core.compiler.codegen.targetPlatform=11
 org.eclipse.jdt.core.compiler.compliance=11
 org.eclipse.jdt.core.compiler.problem.assertIdentifier=error
+org.eclipse.jdt.core.compiler.problem.discouragedReference=ignore
 org.eclipse.jdt.core.compiler.problem.enumIdentifier=error
 org.eclipse.jdt.core.compiler.source=11

--- a/com.wamas.ide.launching.ui/.settings/org.eclipse.xtend.core.Xtend.prefs
+++ b/com.wamas.ide.launching.ui/.settings/org.eclipse.xtend.core.Xtend.prefs
@@ -1,0 +1,3 @@
+ValidatorConfiguration.is_project_specific=true
+eclipse.preferences.version=1
+org.eclipse.xtext.xbase.validation.IssueCodes.null_safe_feature_call_on_primitive_valued_feature=ignore

--- a/com.wamas.ide.launching.ui/src/com/wamas/ide/launching/ui/launchview/LcDslLaunchObject.java
+++ b/com.wamas.ide.launching.ui/src/com/wamas/ide/launching/ui/launchview/LcDslLaunchObject.java
@@ -34,6 +34,7 @@ import com.wamas.ide.launching.ui.LcDslHelper;
 import com.wamas.ide.launching.ui.internal.LaunchingActivator;
 import com.wamas.ide.launching.ui.internal.LcDslInternalHelper;
 
+@SuppressWarnings("restriction")
 public class LcDslLaunchObject implements ILaunchObject {
 
     private static final ImageDescriptor NATURE_OVERLAY = LaunchingActivator

--- a/com.wamas.ide.launching/.settings/org.eclipse.jdt.core.prefs
+++ b/com.wamas.ide.launching/.settings/org.eclipse.jdt.core.prefs
@@ -3,5 +3,6 @@ org.eclipse.jdt.core.compiler.codegen.inlineJsrBytecode=enabled
 org.eclipse.jdt.core.compiler.codegen.targetPlatform=11
 org.eclipse.jdt.core.compiler.compliance=11
 org.eclipse.jdt.core.compiler.problem.assertIdentifier=error
+org.eclipse.jdt.core.compiler.problem.discouragedReference=ignore
 org.eclipse.jdt.core.compiler.problem.enumIdentifier=error
 org.eclipse.jdt.core.compiler.source=11

--- a/com.wamas.ide.launching/.settings/org.eclipse.xtend.core.Xtend.prefs
+++ b/com.wamas.ide.launching/.settings/org.eclipse.xtend.core.Xtend.prefs
@@ -1,0 +1,3 @@
+ValidatorConfiguration.is_project_specific=true
+eclipse.preferences.version=1
+org.eclipse.xtext.xbase.validation.IssueCodes.null_safe_feature_call_on_primitive_valued_feature=ignore

--- a/com.wamas.ide.launching/src/com/wamas/ide/launching/LcDsl.xtext
+++ b/com.wamas.ide.launching/src/com/wamas/ide/launching/LcDsl.xtext
@@ -286,8 +286,10 @@ enum TestRunnerType:
 	JUNIT5 = "junit5" | JUNIT4 = "junit4" | JUNIT3 = "junit3"
 ;
 
+@Override 
 terminal INT returns ecore::EInt: ('0'..'9')+;
 terminal BOOLEAN returns ecore::EBoolean: ('true' | 'false');
+@Override 
 terminal ID: '^'?('a'..'z'|'A'..'Z'|'_') ('.'? ('a'..'z'|'A'..'Z'|'^'|'_'|'-'|'0'..'9'))*;
 terminal QUALIFIER: ('a'..'z'|'A'..'Z'|'_'|'-'|'0'..'9')*;
 terminal VERSION: INT (('.' INT) (('.' INT) ('.' QUALIFIER)?)?)?;

--- a/com.wamas.ide.launching/src/com/wamas/ide/launching/generator/DependencyResolver.xtend
+++ b/com.wamas.ide.launching/src/com/wamas/ide/launching/generator/DependencyResolver.xtend
@@ -25,7 +25,6 @@ import static extension com.wamas.ide.launching.generator.RecursiveCollectors.*
 import com.wamas.ide.launching.lcDsl.LaunchConfigType
 import org.eclipse.pde.internal.core.TargetPlatformHelper
 import org.eclipse.pde.internal.core.PDEState
-import org.eclipse.pde.core.plugin.IPluginModelBase
 
 class DependencyResolver {
 
@@ -171,7 +170,6 @@ class DependencyResolver {
 
 	private static def findPluginConfigurationsInProduct(IFile product) {
 		val model = new WorkspaceProductModel(product, false)
-		val result = newArrayList
 
 		model.load
 

--- a/com.wamas.ide.launching/src/com/wamas/ide/launching/generator/StandaloneLaunchConfigGenerator.xtend
+++ b/com.wamas.ide.launching/src/com/wamas/ide/launching/generator/StandaloneLaunchConfigGenerator.xtend
@@ -37,10 +37,7 @@ import org.eclipse.pde.ui.launcher.EclipseLaunchShortcut
 import org.eclipse.xtext.naming.IQualifiedNameProvider
 
 import static extension com.wamas.ide.launching.generator.RecursiveCollectors.*
-import org.eclipse.pde.core.plugin.TargetPlatform
 import org.eclipse.jdt.internal.junit.launcher.JUnitLaunchConfigurationConstants
-import org.eclipse.jdt.internal.junit.launcher.TestKindRegistry
-import org.eclipse.debug.internal.core.LaunchConfiguration
 import org.eclipse.emf.ecore.InternalEObject
 
 class StandaloneLaunchConfigGenerator {

--- a/com.wamas.ide.launching/src/com/wamas/ide/launching/validation/LcDslValidator.xtend
+++ b/com.wamas.ide.launching/src/com/wamas/ide/launching/validation/LcDslValidator.xtend
@@ -44,7 +44,6 @@ import org.eclipse.pde.internal.core.PDECore
 import org.eclipse.xtext.validation.Check
 
 import static com.wamas.ide.launching.lcDsl.LaunchConfigType.*
-import org.eclipse.jdt.core.IAnnotation
 import org.eclipse.jdt.core.IType
 
 /**


### PR DESCRIPTION
* remove not needed gitignore from /src, it causes a duplicate resource
warning for the binary path (this could also be fixed by enabling a
resource copy filter in the JDT project properties)
* remove unused imports
* disable discouraged access warnings in Java
* disable primitive valued warnings in Xtend

There are no functional changes, and the only remaining warnings are
some grammar warnings. The disablement of warnings sets single project
properties and does not contain complete .prefs files to modify as
little as possible.