### PR TITLE
keep generated launch config upon launch failure for analysis

### DIFF
--- a/com.wamas.ide.launching.ui/src/com/wamas/ide/launching/ui/LcDslHelper.java
+++ b/com.wamas.ide.launching.ui/src/com/wamas/ide/launching/ui/LcDslHelper.java
@@ -197,8 +197,9 @@ public class LcDslHelper {
         }
 
         try {
+            int exitCode = 0;
             try {
-                int exitCode = LaunchConfigurationViewPlugin.getExecutor().launchProcess(c, mode, build, wait, log);
+                exitCode = LaunchConfigurationViewPlugin.getExecutor().launchProcess(c, mode, build, wait, log);
                 if (exitCode != 0) {
                     if (TAIL_LINES > 0 && log != null && log.exists()) {
                         try {
@@ -219,6 +220,10 @@ public class LcDslHelper {
                             "Process " + config.getName() + " did exit with error " + exitCode + ". Logfile does not exist.");
                 }
             } finally {
+                if (exitCode == 13) { // bad luck launching the application
+                    // keep the logs around, which are stored within the generated configuration
+                    removeAfterLaunch = false;
+                }
                 if (removeAfterLaunch) {
                     c.delete();
                 }


### PR DESCRIPTION
When there is some problem around launching itself, the path to Eclipse's log file is printed - but that one is removed together with the generated launch config.

TODO: Discuss+define some property somewhere to enable this for a particular launch config only.