### PR TITLE
Do not inherit "favorite" property

### DIFF
--- a/com.wamas.ide.launching/src/com/wamas/ide/launching/generator/RecursiveCollectors.xtend
+++ b/com.wamas.ide.launching/src/com/wamas/ide/launching/generator/RecursiveCollectors.xtend
@@ -267,9 +267,12 @@ class RecursiveCollectors {
 	}
 
 	static def collectFavoriteGroups(LaunchConfig config) {
-		collectFlatList(config, [
-			favorites?.types?.map[favoriteGroupMap.get(it)]
-		])
+		var result = newArrayList()
+		val v = config?.favorites?.types?.map[favoriteGroupMap.get(it)];
+		if (v !== null) {
+			result.addAll(v)
+		}
+		result
 	}
 
 	static def collectGroupMembers(LaunchConfig config) {


### PR DESCRIPTION
Each LC that should be shown under "Favorites" should marked as such itself.