### PR TITLE
ignored plugin has to exactly match the version, if any - #95

### DIFF
--- a/com.wamas.ide.launching.feature/feature.xml
+++ b/com.wamas.ide.launching.feature/feature.xml
@@ -2,7 +2,7 @@
 <feature
       id="com.wamas.ide.launching.feature"
       label="Launch Configuration DSL"
-      version="1.0.0.qualifier"
+      version="1.1.0.qualifier"
       provider-name="SSI Schaefer IT Solutions GmbH">
 
    <description>

--- a/com.wamas.ide.launching.feature/pom.xml
+++ b/com.wamas.ide.launching.feature/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <artifactId>com.wamas.ide.launching-parent</artifactId>
     <groupId>com.wamas.ide.launching</groupId>
-    <version>1.0.0-SNAPSHOT</version>
+    <version>1.1.0-SNAPSHOT</version>
   </parent>
   <artifactId>com.wamas.ide.launching.feature</artifactId>
   <packaging>eclipse-feature</packaging>

--- a/com.wamas.ide.launching.ide/META-INF/MANIFEST.MF
+++ b/com.wamas.ide.launching.ide/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: LcDsl IDE Support
 Bundle-Vendor: SSI Schaefer IT Solutions GmbH
-Bundle-Version: 1.0.0.qualifier
+Bundle-Version: 1.1.0.qualifier
 Bundle-SymbolicName: com.wamas.ide.launching.ide; singleton:=true
 Bundle-ActivationPolicy: lazy
 Require-Bundle: com.wamas.ide.launching,

--- a/com.wamas.ide.launching.ide/build.properties
+++ b/com.wamas.ide.launching.ide/build.properties
@@ -1,6 +1,7 @@
 source.. = src/main/java,\
            src/gen/xtext,\
            target/generated-sources/xtend/
+output.. = bin/
 bin.includes = .,\
                META-INF/
 javacDefaultEncoding.. = UTF-8

--- a/com.wamas.ide.launching.ide/pom.xml
+++ b/com.wamas.ide.launching.ide/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <artifactId>com.wamas.ide.launching-parent</artifactId>
     <groupId>com.wamas.ide.launching</groupId>
-    <version>1.0.0-SNAPSHOT</version>
+    <version>1.1.0-SNAPSHOT</version>
   </parent>
   <artifactId>com.wamas.ide.launching.ide</artifactId>
   <packaging>eclipse-plugin</packaging>

--- a/com.wamas.ide.launching.ui/META-INF/MANIFEST.MF
+++ b/com.wamas.ide.launching.ui/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: LcDsl IDE UI
 Bundle-Vendor: SSI Schaefer IT Solutions GmbH
-Bundle-Version: 1.0.0.qualifier
+Bundle-Version: 1.1.0.qualifier
 Bundle-SymbolicName: com.wamas.ide.launching.ui; singleton:=true
 Bundle-ActivationPolicy: lazy
 Require-Bundle: com.wamas.ide.launching,
@@ -22,7 +22,7 @@ Require-Bundle: com.wamas.ide.launching,
  org.eclipse.jdt.launching,
  org.eclipse.e4.ui.model.workbench,
  org.eclipse.e4.core.di.annotations,
- org.eclipse.debug.ui.launchview;bundle-version="1.0.0",
+ org.eclipse.debug.ui.launchview;bundle-version="1.1.0",
  org.eclipse.core.variables,
  org.eclipse.pde.ui
 Import-Package: org.apache.log4j

--- a/com.wamas.ide.launching.ui/build.properties
+++ b/com.wamas.ide.launching.ui/build.properties
@@ -1,6 +1,7 @@
 source.. = src/main/java,\
            src/gen/xtext,\
            target/generated-sources/xtend/
+output.. = bin/
 bin.includes = .,\
                META-INF/,\
                plugin.xml,\

--- a/com.wamas.ide.launching.ui/pom.xml
+++ b/com.wamas.ide.launching.ui/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <artifactId>com.wamas.ide.launching-parent</artifactId>
     <groupId>com.wamas.ide.launching</groupId>
-    <version>1.0.0-SNAPSHOT</version>
+    <version>1.1.0-SNAPSHOT</version>
   </parent>
   <artifactId>com.wamas.ide.launching.ui</artifactId>
   <packaging>eclipse-plugin</packaging>

--- a/com.wamas.ide.launching.update/pom.xml
+++ b/com.wamas.ide.launching.update/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <artifactId>com.wamas.ide.launching-parent</artifactId>
     <groupId>com.wamas.ide.launching</groupId>
-    <version>1.0.0-SNAPSHOT</version>
+    <version>1.1.0-SNAPSHOT</version>
   </parent>
   <artifactId>com.wamas.ide.launching.update</artifactId>
   <packaging>eclipse-repository</packaging>

--- a/com.wamas.ide.launching/META-INF/MANIFEST.MF
+++ b/com.wamas.ide.launching/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: LcDsl Core
 Bundle-Vendor: SSI Schaefer IT Solutions GmbH
-Bundle-Version: 1.0.0.qualifier
+Bundle-Version: 1.1.0.qualifier
 Bundle-SymbolicName: com.wamas.ide.launching; singleton:=true
 Bundle-ActivationPolicy: lazy
 Require-Bundle: org.eclipse.xtext,

--- a/com.wamas.ide.launching/build.properties
+++ b/com.wamas.ide.launching/build.properties
@@ -1,6 +1,7 @@
 source.. = src/main/java,\
            src/gen/xtext,\
            target/generated-sources/xtend
+output.. = bin/
 bin.includes = model/generated/,\
                .,\
                META-INF/,\

--- a/com.wamas.ide.launching/pom.xml
+++ b/com.wamas.ide.launching/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <artifactId>com.wamas.ide.launching-parent</artifactId>
     <groupId>com.wamas.ide.launching</groupId>
-    <version>1.0.0-SNAPSHOT</version>
+    <version>1.1.0-SNAPSHOT</version>
   </parent>
   <artifactId>com.wamas.ide.launching</artifactId>
   <packaging>eclipse-plugin</packaging>

--- a/com.wamas.ide.launching/src/main/java/com/wamas/ide/launching/generator/DependencyResolver.xtend
+++ b/com.wamas.ide.launching/src/main/java/com/wamas/ide/launching/generator/DependencyResolver.xtend
@@ -68,7 +68,7 @@ class DependencyResolver {
 		val cp = config.collectContentProvider
 		val fState=TargetPlatformHelper.getPDEState();
 
-		val mappedIgnores = ignores.map[getBestPluginMatch(it.name, it.version)?.bundleDescription].filterNull.toList
+		val mappedIgnores = ignores.map[getExactPluginMatch(it.name, it.version)?.bundleDescription].filterNull.toList
 		var Map<BundleDescription, StartLevel> allBundles = newHashMap()
 
 		if (cp !== null && !cp.empty) {
@@ -252,6 +252,10 @@ class DependencyResolver {
 		}
 
 		bundle
+	}
+
+	private static def getExactPluginMatch(String id, String version) {
+		PluginRegistry.findModels(id, version, VersionMatchRule.PERFECT).findFirst.orElse(null)
 	}
 
 	private static def getPluginModels(IProductModel pm) {

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
   <groupId>com.wamas.ide.launching</groupId>
   <artifactId>com.wamas.ide.launching-parent</artifactId>
-  <version>1.0.0-SNAPSHOT</version>
+  <version>1.1.0-SNAPSHOT</version>
   <packaging>pom</packaging>
 
   <properties>


### PR DESCRIPTION
When a plugin to be ignored is declared with a version number, but that version does not actually exist at all, we have ignored the most recent version available for that plugin name.
Instead, this 'ignore' statement should not apply, because ignoring a specific version usually has a specific reason related to that version.